### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/code_snippets/python/csv_snip.py
+++ b/code_snippets/python/csv_snip.py
@@ -5,8 +5,8 @@ class DictWriter:
         self.restval = restval          # for writing short dicts
         if extrasaction.lower() not in ("raise", "ignore"):
             raise ValueError, \
-                  ("extrasaction (%s) must be 'raise' or 'ignore'" %
-                   extrasaction)
+                  ("extrasaction ({0!s}) must be 'raise' or 'ignore'".format(
+                   extrasaction))
         self.extrasaction = extrasaction
         self.writer = writer(f, dialect, *args, **kwds)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:girishramnani:t3?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:girishramnani:t3?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
